### PR TITLE
Return numeric temperature and add service test

### DIFF
--- a/src/main/java/com/preinterview/assignment/controller/OpenMeteoForecastWrapperController.java
+++ b/src/main/java/com/preinterview/assignment/controller/OpenMeteoForecastWrapperController.java
@@ -9,8 +9,9 @@ public class OpenMeteoForecastWrapperController {
     private OpenmeteoforecastService  openmeteoforecastService;
 
     @GetMapping("/weather")
-    public @ResponseBody Object getTemprature(@RequestParam double latitude, @RequestParam double longitude) {
-        return  openmeteoforecastService.getTemparature(latitude,longitude);
+    public @ResponseBody double getTemperature(@RequestParam double latitude,
+                                               @RequestParam double longitude) {
+        return openmeteoforecastService.getTemperature(latitude, longitude);
     }
 
 

--- a/src/main/java/com/preinterview/assignment/service/OpenmeteoforecastService.java
+++ b/src/main/java/com/preinterview/assignment/service/OpenmeteoforecastService.java
@@ -12,21 +12,30 @@ public class OpenmeteoforecastService {
 
     @Autowired
     RestTemplate restTemplate;
-    public Object getTemparature(double latitude, double longitude){
-        String URL = "https://api.open-meteo.com/v1/forecast?" +
+
+    /**
+     * Calls the Open Meteo forecast API and extracts the current temperature.
+     *
+     * @param latitude  latitude of the location
+     * @param longitude longitude of the location
+     * @return the current temperature in degrees Celsius
+     */
+    public double getTemperature(double latitude, double longitude) {
+        String url = "https://api.open-meteo.com/v1/forecast?" +
                 "latitude=" + latitude + "&longitude=" + longitude + "&current=temperature_2m";
-        //response from the open-meteo forcast API
-        ResponseEntity<String> response
-                = restTemplate.getForEntity(URL, String.class);
-        // ObjectMapper to get temprature from the response
+
+        // response from the open-meteo forecast API
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+        // ObjectMapper to get temperature from the response
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = null;
+        JsonNode root;
         try {
             root = mapper.readTree(response.getBody());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
         JsonNode current = root.path("current");
-        return current.path("temperature_2m");
+        return current.path("temperature_2m").asDouble();
     }
 }

--- a/src/test/java/com/preinterview/assignment/service/OpenmeteoforecastServiceTest.java
+++ b/src/test/java/com/preinterview/assignment/service/OpenmeteoforecastServiceTest.java
@@ -1,0 +1,41 @@
+package com.preinterview.assignment.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Tests for {@link OpenmeteoforecastService}.
+ */
+class OpenmeteoforecastServiceTest {
+
+    @Test
+    void returnsTemperatureFromApiResponse() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+
+        OpenmeteoforecastService service = new OpenmeteoforecastService();
+        service.restTemplate = restTemplate;
+
+        double latitude = 10.0;
+        double longitude = 20.0;
+
+        String url = "https://api.open-meteo.com/v1/forecast?" +
+                "latitude=" + latitude + "&longitude=" + longitude + "&current=temperature_2m";
+        String json = "{\"current\":{\"temperature_2m\":15.5}}";
+
+        server.expect(requestTo(url))
+              .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        double temperature = service.getTemperature(latitude, longitude);
+
+        assertEquals(15.5, temperature);
+        server.verify();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Return primitive double from Open-Meteo service instead of JsonNode
- Rename controller endpoint method accordingly
- Add unit test validating temperature parsing using MockRestServiceServer

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688db2353b3c832c9b6dadfce231eb75